### PR TITLE
Keep dropdown open when selecting multiple columns to hide - CloseOnClick

### DIFF
--- a/src/Backgrid.ColumnManager.js
+++ b/src/Backgrid.ColumnManager.js
@@ -5,11 +5,13 @@
  *
  * @module Backgrid.ColumnManager
  */
+
 // Dependencies
 var _ = require("underscore");
 var $ = require("jquery");
 var Backbone = require("backbone");
 var Backgrid = require("backgrid");
+var COLUMN_MANAGER_PREFIX = "columnmanager";
 
 /**
  * Manages visibility of columns.
@@ -653,7 +655,7 @@ Backgrid.Extension.ColumnManagerVisibilityControl = Backbone.View.extend({
    * @type String
    * @default "columnmanager-visibilitycontrol"
    */
-  className: "columnmanager-visibilitycontrol",
+  className: "columnmanager-visibilitycontrol",  
 
   /**
    * @property defaultEvents
@@ -799,7 +801,7 @@ Backgrid.Extension.ColumnManagerVisibilityControl = Backbone.View.extend({
    * @method toggle
    * @param {object} [e]
    */
-  toggle: function (e) {
+  toggle: function (e) {    
     if (this.isOpen !== true) {
       this.open(e);
     }
@@ -852,7 +854,6 @@ Backgrid.Extension.ColumnManagerVisibilityControl = Backbone.View.extend({
     if (!this.isOpen) {
       return;
     }
-
     this.isOpen = false;
     this.$el.removeClass("open");
     this.trigger("dropdown:closed");
@@ -874,12 +875,23 @@ Backgrid.Extension.ColumnManagerVisibilityControl = Backbone.View.extend({
     }
   },
 
-  /**
+  /** 
+   * Close dropdown only if control was not clicked 
+   *
    * @method deferClose
    * @private
    */
-  deferClose: function () {
-    this.deferCloseTimeout = setTimeout(this.close.bind(this), 0);
+  deferClose: function (e) {    
+    if(this.options.closeOnClick) this.deferCloseTimeout = setTimeout(this.close.bind(this), 0);
+
+    var clickedClassName = e.target.parentElement.classList.item(0);
+    var columnManagerClassPrefix = (clickedClassName) ? clickedClassName.split("-")[0] : "";    
+    var controlClicked = columnManagerClassPrefix === COLUMN_MANAGER_PREFIX;    
+    if(!controlClicked && this.isOpen === true) {
+      this.deferCloseTimeout = setTimeout(this.close.bind(this), 0);
+    } else if(this.className === clickedClassName && this.isOpen === true){
+      this.deferCloseTimeout = setTimeout(this.close.bind(this), 0);
+    }    
   },
 
   /**


### PR DESCRIPTION
This implements one of the defaultOpts in Backgrid.Extension.ColumnManagerVisibilityControl - CloseOnClick.

Normally, when I click the control the dropdown opens, and I select a column to hide or display. After this the dropdown closes. 

However, what if one wanted to select multiple columns to hide/display? One would have to click the control every time.

If CloseOnClick is set to false when instantiating a ColumnManagerVisiblityControl, the dropdown only closes when a user clicks outside of the control or on the button itself. 

This way, a user can select as many or as little columns to hide or display.
